### PR TITLE
Download step

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -3,10 +3,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python=3.8.17
   - requests=2.24.0
   - pip=20.3.3
   - mlflow=1.14.1
   - hydra-core=1.0.6
+  - numpy=1.19.5
   - pip:
       - wandb==0.10.21
       - hydra-joblib-launcher==1.1.2

--- a/download/conda.yml
+++ b/download/conda.yml
@@ -3,7 +3,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python 3.8.17
   - requests=2.24.0
   - pip=20.3.3
   - pip:
       - wandb==0.10.21
+      - protobuf==3.20.0


### PR DESCRIPTION
Fix conda.yml and download/conda.yml files. 
Python 3.9 was being installed when running the starter kit as it was. Some incompatibility issues were also observed with the NumPy's version.

conda.yml
- Fix Python's version
- Fix NumPy's version

download/conda.yml
- Fix Python's version
- Fix protobuf version